### PR TITLE
Do not pass token as argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,4 +16,3 @@ runs:
   args:
     - ${{ inputs.version }}
     - ${{ inputs.specfiles }}
-    - ${{ inputs.token }}


### PR DESCRIPTION
The script expects only version and path to specfile, not token. The token is obtained from `INPUT_` env var, therefore we shouldn't pass it in.